### PR TITLE
fix: custom form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ export default config;
 ### Options
 
 - `fields`
-  An object of field types to allow your admin editors to build forms with. Pass either a boolean value or a partial [Payload Block](https://payloadcms.com/docs/fields/blocks#block-configs) to override default settings. See [Fields](#fields) for more details.
+
+  An object of field types to allow your admin editors to build forms with. To override default settings pass either a boolean value or a partial [Payload Block](https://payloadcms.com/docs/fields/blocks#block-configs) keyed to the block slug. See [Fields](#fields) for more details.
 
   ```js
   fields: {
@@ -111,13 +112,20 @@ export default config;
 
   Override anything on the form collection by sending a [Payload Collection Config](https://payloadcms.com/docs/configuration/collections). Your overrides will be merged into the default `forms` collection.
 
-  ```js
+  ```ts
   formOverrides: {
-    slug: "contact-forms";
+    slug: "contact-forms",
+    fields: [
+      {
+        name: "custom-field",
+        type: "text"
+      }
+    ]
   }
   ```
 
 - `formSubmissionOverrides`
+
   By default, this plugin relies on [Payload access control](https://payloadcms.com/docs/access-control/collections) to restrict the `update` and `read` operations. This is because anyone should be able to create a form submission, even from a public-facing website - but no one should be able to update a submission one it has been created, or read a submission unless they have permission.
 
   You can override access control and anything else on the form submission collection by sending a [Payload Collection Config](https://payloadcms.com/docs/configuration/collections). Your overrides will be merged into the default `formSubmissions` collection.
@@ -130,7 +138,7 @@ export default config;
 
 ## Fields
 
-Each form field is defined as a [Payload Block](https://payloadcms.com/docs/fields/blocks) with the following subfields:
+Each field represents a form input. To override default settings pass either a boolean value or a partial [Payload Block](https://payloadcms.com/docs/fields/blocks) keyed to the block's slug.
 
 - Text
   - `name`: string
@@ -246,7 +254,7 @@ To actively develop or debug this plugin you can either work directly within the
 
    You might also need to alias these modules in your Webpack config. To do this, open your project's Payload config and add the following:
 
-   ```js
+   ```ts
    import { buildConfig } from "payload/config";
 
    export default buildConfig({

--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -4,6 +4,21 @@ import path from 'path';
 import formBuilderPlugin from '../../src';
 import { Users } from './collections/Users';
 import { Pages } from './collections/Pages';
+import { Block } from 'payload/types';
+
+const colorField: Block = {
+  slug: 'color',
+  labels: {
+    singular: 'Color',
+    plural: 'Colors',
+  },
+  fields: [
+    {
+      name: 'value',
+      type: 'text',
+    }
+  ]
+}
 
 export default buildConfig({
   serverURL: 'http://localhost:3000',
@@ -37,8 +52,17 @@ export default buildConfig({
       redirectRelationships: [
         'pages'
       ],
+      formOverrides: {
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          }
+        ]
+      },
       fields: {
         payment: true,
+        colorField,
         // payment: {
         //     paymentProcessor: {
         //       options: [

--- a/src/collections/Forms/fields.ts
+++ b/src/collections/Forms/fields.ts
@@ -576,5 +576,5 @@ export default {
   state: State,
   payment: Payment
 } as {
-  [key: string]: Block | ((fieldConfig: FieldConfig) => Block)
+  [key: string]: Block | ((fieldConfig?: boolean | FieldConfig) => Block)
 };

--- a/src/collections/Forms/index.ts
+++ b/src/collections/Forms/index.ts
@@ -65,9 +65,9 @@ export const generateFormCollection = (formConfig: PluginConfig): CollectionConf
   const config: CollectionConfig = {
     slug: formConfig?.formOverrides?.slug || 'forms',
     admin: {
-      ...formConfig?.formOverrides?.admin || {},
       useAsTitle: 'title',
       enableRichTextRelationship: false,
+      ...formConfig?.formOverrides?.admin || {},
     },
     access: {
       read: () => true,
@@ -87,6 +87,10 @@ export const generateFormCollection = (formConfig: PluginConfig): CollectionConf
           if (fieldConfig !== false) {
             let block = fields[fieldKey];
 
+            if (block === undefined && typeof fieldConfig === 'object') {
+              return fieldConfig
+            }
+
             if (typeof block === 'object' && typeof fieldConfig === 'object') {
               return merge<FieldConfig>(block, fieldConfig, {
                 arrayMerge: (_, sourceArray) => sourceArray
@@ -94,7 +98,7 @@ export const generateFormCollection = (formConfig: PluginConfig): CollectionConf
             }
 
             if (typeof block === 'function') {
-              return block(fieldConfig as FieldConfig);
+              return block(fieldConfig);
             }
 
             return block;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type FieldsConfig = {
   number?: boolean | FieldConfig
   message?: boolean | FieldConfig
   payment?: boolean | FieldConfig
+  [key: string]: boolean | FieldConfig | undefined
 }
 
 export type BeforeEmail = (emails: FormattedEmail[]) => FormattedEmail[] | Promise<FormattedEmail[]>;


### PR DESCRIPTION
Resolves #15 by correctly returning custom form fields [here](https://github.com/payloadcms/plugin-form-builder/compare/fix/15?expand=1#diff-687c4bef9fb3943d1505c9dabc9b56f96def137bf7d896938dd359641775e4ddR90) and fixing the type definitions [here](https://github.com/payloadcms/plugin-form-builder/compare/fix/15?expand=1#diff-2849e31129fe42061adaa11db90177c07105ab8cf7db88e0a1e28276b5787b48R579) and [here](https://github.com/payloadcms/plugin-form-builder/compare/fix/15?expand=1#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR35).