### PR TITLE
fix: properly exports types

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ import {
   FormSubmission,
   FieldsConfig,
   BeforePayment,
+  BeforeEmail,
   HandlePayment,
-} from "@payloadcms/plugin-form-builder/dist/types";
+  ...
+} from "@payloadcms/plugin-form-builder/types";
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "typescript": "^4.5.5"
   },
   "files": [
-    "dist"
+    "dist",
+    "types.js",
+    "types.d.ts"
   ],
   "dependencies": {
     "deepmerge": "^4.2.2",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/types.js
+++ b/types.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/types');


### PR DESCRIPTION
Now types can be imported from `@payloadcms/plugin-form-builder/types` instead of `@payloadcms/form-builder/dist/types`.