### PR TITLE
fix: uses form slug from config in form relationship field #19

### DIFF
--- a/src/collections/FormSubmissions/index.ts
+++ b/src/collections/FormSubmissions/index.ts
@@ -27,7 +27,7 @@ export const generateSubmissionCollection = (formConfig: PluginConfig): Collecti
     },
     fields: [
       {
-        name: 'form',
+        name: formConfig?.formOverrides?.slug || 'form',
         type: 'relationship',
         relationTo: 'forms',
         required: true,


### PR DESCRIPTION
Fixes #19 by using the form slug from the config in the form relationship field.