### PR TITLE
fix: removes conditional return of formattedEmails in sendEmail hook #26

### DIFF
--- a/src/collections/FormSubmissions/hooks/sendEmail.ts
+++ b/src/collections/FormSubmissions/hooks/sendEmail.ts
@@ -57,25 +57,23 @@ const sendEmail = async (beforeChangeData: any, formConfig: PluginConfig) => {
             const from = replaceDoubleCurlys(emailFrom, submissionData);
             const replyTo = replaceDoubleCurlys(emailReplyTo || emailFrom, submissionData);
 
-            if (to && from) {
-              return ({
-                to,
-                from,
-                cc,
-                bcc,
-                replyTo,
-                subject: replaceDoubleCurlys(subject, submissionData),
-                html: `<div>${serialize(message, submissionData)}</div>`
-              });
-            }
-            return null
-          }).filter(Boolean);
+            return ({
+              to,
+              from,
+              cc,
+              bcc,
+              replyTo,
+              subject: replaceDoubleCurlys(subject, submissionData),
+              html: `<div>${serialize(message, submissionData)}</div>`
+            });
+          });
 
           let emailsToSend = formattedEmails
 
           if (typeof beforeEmail === 'function') {
             emailsToSend = await beforeEmail(formattedEmails);
           }
+
           const log = emailsToSend.map(({ html, ...rest }) => ({ ...rest }))
 
           await Promise.all(

--- a/src/collections/Forms/index.ts
+++ b/src/collections/Forms/index.ts
@@ -153,7 +153,6 @@ export const generateFormCollection = (formConfig: PluginConfig): CollectionConf
                 type: 'text',
                 name: 'emailTo',
                 label: 'Email To',
-                required: true,
                 admin: {
                   width: '100%',
                   placeholder: '"Email Sender" <sender@email.com>'


### PR DESCRIPTION
Resolves #26 by removing the conditional return of formattedEmails in the sendEmail hook and removing the `fromEmail` requirement. This way the hook has full control to populate those fields if needed.