### PR TITLE
chore: adds use client directive atop custom react components

### DIFF
--- a/src/collections/Forms/DynamicFieldSelector.tsx
+++ b/src/collections/Forms/DynamicFieldSelector.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useEffect, useState } from 'react'
 import { Select, useForm } from 'payload/components/forms'
 import { TextField } from 'payload/dist/fields/config/types'

--- a/src/collections/Forms/DynamicPriceSelector.tsx
+++ b/src/collections/Forms/DynamicPriceSelector.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useEffect, useState } from 'react';
 import { Text, useWatchForm } from 'payload/components/forms';
 import { Props as TextFieldType } from 'payload/dist/admin/components/forms/field-types/Text/types';


### PR DESCRIPTION
Adds `use client` directives to react components. This is causing issues when using payload inside NextJS /app folder.

[Related next-payload issue](https://github.com/payloadcms/next-payload/issues/27)