### PR TITLE
wip: strictly types fields

### DIFF
--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -68,6 +68,10 @@ export default buildConfig({
       fields: {
         payment: true,
         colorField,
+        newFieldBlock: {
+          slug: 'custom-text-field',
+          fields: [],
+        },
         text: {
           ...fields.text,
           labels: {

--- a/src/collections/Forms/fields.ts
+++ b/src/collections/Forms/fields.ts
@@ -1,6 +1,6 @@
 import type { Block, Field } from 'payload/types'
 
-import type { FieldConfig, PaymentFieldConfig } from '../../types'
+import type { FunctionThatReturnsBlock } from '../../types'
 import { DynamicFieldSelector } from './DynamicFieldSelector'
 import { DynamicPriceSelector } from './DynamicPriceSelector'
 
@@ -392,9 +392,10 @@ const Checkbox: Block = {
   ],
 }
 
-const Payment = (fieldConfig: PaymentFieldConfig): Block => {
+const Payment: FunctionThatReturnsBlock = fieldConfig => {
   let paymentProcessorField = null
-  if (fieldConfig?.paymentProcessor) {
+
+  if (fieldConfig && typeof fieldConfig === 'object' && 'paymentProcessor' in fieldConfig) {
     paymentProcessorField = {
       type: 'select',
       options: [],
@@ -571,7 +572,6 @@ const Message: Block = {
   ],
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const fields = {
   select: Select,
   checkbox: Checkbox,
@@ -583,8 +583,6 @@ export const fields = {
   country: Country,
   state: State,
   payment: Payment,
-} as {
-  [key: string]: Block | ((fieldConfig?: boolean | FieldConfig) => Block)
 }
 
 export default fields

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const FormBuilder =
         checkbox: true,
         message: true,
         payment: false,
-        ...incomingFormConfig.fields,
+        ...(incomingFormConfig?.fields || {}),
       },
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { Block, CollectionConfig, Field } from 'payload/types'
 
+import type formFields from './collections/Forms/fields'
+
 export interface BlockConfig {
   block: Block
   validate?: (value: unknown) => boolean | string
@@ -21,23 +23,22 @@ export type PaymentFieldConfig = Partial<Field> & {
   paymentProcessor: Partial<SelectField>
 }
 
-export type FieldConfig = Partial<Field> | PaymentFieldConfig
-
-export interface FieldsConfig {
-  select?: boolean | FieldConfig
-  text?: boolean | FieldConfig
-  textarea?: boolean | FieldConfig
-  email?: boolean | FieldConfig
-  state?: boolean | FieldConfig
-  country?: boolean | FieldConfig
-  checkbox?: boolean | FieldConfig
-  number?: boolean | FieldConfig
-  message?: boolean | FieldConfig
-  payment?: boolean | FieldConfig
-  [key: string]: boolean | FieldConfig | undefined
+export interface FunctionThatReturnsBlock {
+  (fieldConfig?: boolean | Partial<Field> | PaymentFieldConfig): Block
 }
 
+export type FieldsConfig = {
+  [key in keyof typeof formFields]: boolean | Partial<Field>
+} & {
+  payment: boolean | PaymentFieldConfig
+} & {
+  [key: string]: Block | FunctionThatReturnsBlock
+}
+
+export type FieldConfig = FieldsConfig[keyof FieldsConfig]
+
 export type BeforeEmail = (emails: FormattedEmail[]) => FormattedEmail[] | Promise<FormattedEmail[]>
+
 export type HandlePayment = (data: any) => void
 
 export interface PluginConfig {


### PR DESCRIPTION
Resolves #34 by strictly typing fields.

**HELP NEEDED**

I can't seem to get these stricter types to resolve in my intersection. Basically I have an object with known properties of Type A and unknown properties of Type B. Here's a very simple breakdown of my exact issue:

```ts
export type BaseFields = {
  text: boolean | Partial<Field>
} & {
  [key: string]:
    Block
    | ((fieldConfig?: FieldConfig) => Block)
}

const baseFields: BaseFields = {
  text: true,
}

// Produces this error
// Property 'text' is incompatible with index signature.
//       Type 'boolean' is not assignable to type 'Block | ((fieldConfig?: FieldConfig) => Block)'.

// Note: Using `Exclude` on the union type also does not work, i.e. [key: Exclude<string, 'text'>]: Block | (fieldConfig?: FieldConfig) => Block
```

Here's the exact errors I'm running into with this code:

![Screenshot 2023-05-15 at 5 05 41 PM](https://github.com/payloadcms/plugin-form-builder/assets/15735305/c338125a-e2d6-4584-afb6-b71e940ded64)
![Screenshot 2023-05-15 at 5 05 32 PM](https://github.com/payloadcms/plugin-form-builder/assets/15735305/3c1e55d2-e040-42b8-befc-cb7c8415b353)

I found a related GitHub discussion here: https://github.com/microsoft/TypeScript/issues/20597
