### PR TITLE
feat: add serverside validation to form submission

### DIFF
--- a/src/collections/FormSubmissions/hooks/validateSubmission.ts
+++ b/src/collections/FormSubmissions/hooks/validateSubmission.ts
@@ -1,0 +1,57 @@
+import { PluginConfig } from '../../../types'
+import { PayloadRequest, Field } from 'payload/types'
+
+interface UnknownFormSubmission {
+  data?: Partial<any> | undefined
+  req?: PayloadRequest | undefined
+  operation: 'create' | 'update'
+  originalDoc?: any
+}
+
+interface FormSubmission {
+  data: {
+    form: string
+    submissionData: {
+      field: string
+      value: string
+    }[]
+  }
+  req: PayloadRequest
+  operation: 'create' | 'update'
+}
+
+export const prepareSubmissionForValidation = async (
+  unknownFormSubmission: UnknownFormSubmission,
+  formConfig: PluginConfig,
+) => {
+  const {
+    req: { payload },
+    data,
+  } = unknownFormSubmission as FormSubmission
+
+  const { form, submissionData } = data
+
+  const query = await payload?.find({
+    collection: formConfig?.formOverrides?.slug || 'forms',
+    where: {
+      id: {
+        equals: form,
+      },
+    },
+  })
+
+  if (!query?.docs[0]) {
+    throw new Error('Form not found')
+  }
+
+  const fieldConfigs = query?.docs[0].fields as Field[]
+
+  fieldConfigs.map(field => {
+    if ('name' in field && !submissionData.find(s => s.field === field.name)) {
+      // If any fields are missing from the submission data, add them with an empty string and allow them to be validated on the field level
+      submissionData.push({ field: field.name, value: '' })
+    }
+  })
+
+  return { ...data, submissionData }
+}

--- a/src/collections/FormSubmissions/index.ts
+++ b/src/collections/FormSubmissions/index.ts
@@ -3,6 +3,7 @@ import type { CollectionConfig } from 'payload/types'
 import type { PluginConfig } from '../../types'
 import createCharge from './hooks/createCharge'
 import sendEmail from './hooks/sendEmail'
+import validateSubmissionField from './validators/validateSubmissionField'
 
 // all settings can be overridden by the config
 export const generateSubmissionCollection = (formConfig: PluginConfig): CollectionConfig => {
@@ -53,23 +54,7 @@ export const generateSubmissionCollection = (formConfig: PluginConfig): Collecti
             name: 'value',
             type: 'text',
             required: true,
-            validate: (value: unknown) => {
-              // TODO:
-              // create a validation function that dynamically
-              // relies on the field type and its options as configured.
-
-              // How to access sibling data from this field?
-              // Need the `name` of the field in order to validate it.
-
-              // Might not be possible to use this validation function.
-              // Instead, might need to do all validation in a `beforeValidate` collection hook.
-
-              if (typeof value !== 'undefined') {
-                return true
-              }
-
-              return 'This field is required.'
-            },
+            validate: validateSubmissionField(formConfig),
           },
         ],
       },

--- a/src/collections/FormSubmissions/index.ts
+++ b/src/collections/FormSubmissions/index.ts
@@ -4,6 +4,7 @@ import type { PluginConfig } from '../../types'
 import createCharge from './hooks/createCharge'
 import sendEmail from './hooks/sendEmail'
 import validateSubmissionField from './validators/validateSubmissionField'
+import { prepareSubmissionForValidation } from './hooks/validateSubmission'
 
 // all settings can be overridden by the config
 export const generateSubmissionCollection = (formConfig: PluginConfig): CollectionConfig => {
@@ -25,6 +26,10 @@ export const generateSubmissionCollection = (formConfig: PluginConfig): Collecti
         data => createCharge(data, formConfig),
         data => sendEmail(data, formConfig),
         ...(formConfig?.formSubmissionOverrides?.hooks?.beforeChange || []),
+      ],
+      beforeValidate: [
+        data => prepareSubmissionForValidation(data, formConfig),
+        ...(formConfig?.formSubmissionOverrides?.hooks?.beforeValidate || []),
       ],
       ...(formConfig?.formSubmissionOverrides?.hooks || {}),
     },

--- a/src/collections/FormSubmissions/validators/validateSubmissionField.ts
+++ b/src/collections/FormSubmissions/validators/validateSubmissionField.ts
@@ -1,0 +1,36 @@
+import type { PluginConfig } from '../../../types'
+import { PaginatedDocs } from 'payload/dist/mongoose/types'
+import { CollectionConfig, TextField, Validate } from 'payload/types'
+
+type validationSubmissionField = (
+  formConfig: PluginConfig,
+) => Validate<string, { form: string }, { field: string; value: string }, TextField>
+
+const validateSubmissionField: validationSubmissionField = formConfig => async (value, options) => {
+  const fieldName = options.siblingData.field
+
+  const query: PaginatedDocs<CollectionConfig> | undefined = await options.payload?.find({
+    collection: formConfig?.formOverrides?.slug || 'forms',
+    where: {
+      id: {
+        equals: options.data.form,
+      },
+    },
+  })
+
+  const fieldConfig = query?.docs[0].fields.find(
+    field => 'name' in field && field.name === fieldName,
+  )
+
+  if (fieldConfig) {
+    if ('required' in fieldConfig && fieldConfig.required && !value) {
+      return 'This field is required'
+    }
+  } else {
+    return 'invalid field name'
+  }
+
+  return true
+}
+
+export default validateSubmissionField


### PR DESCRIPTION
## Original
What it does:
- Validates that required fields are not undefined or empty strings.
- Validates that all fields provided by formData exist. 

How it does this:
- Uses field level validation to get the name of the field
- Fetch the matching form, and get the record for that field. 
- If the field does not exist, report as an invalid field name. 
- If the field is required, confirm that it is not empty or undefined. 

What it does not do:
- Validate that required fields are included in the form submission. We can't know this, since the field level validation will never be executed for a field that has not been added to the array. 
- Validate that a valid formID is provided. 

Performance considerations:
- I ran a few quick tests using 2 and 6 fields, and saw no significant impact on querying for the matching form in each fields validate function. 


## Update
Looking at the `beforeValidate` hook, it does not provide an easy way to through field level validation errors. With this in mind, I thought of a solution that keeps validation in the field level, and uses the `beforeValidate` hook in the spirit it was intended-- to prepare for validation.

Required Fields: 
In the updated implementation I've added a `beforeValidate` hook which looks of the form, iterates through its fields, and adds an empty record for any field which was not included in the submission. This allows the field level validator to run on these missing fields, and evaluate if they should be treated as required down the road. 

Invalid Form Names:
* I currently have a check when fetching the form in the `beforeValidate` hook which will return an error if no form is found. It may be preferable to do this validation in the field level too, I'll leave this up to the reviewers discretion. 

Performance:
* This new usage, while meeting of the outlined edge cases, does require some duplicated work. We fetch the form once in the collection hook, and once more for each field. This seems to add a few ms, but nothing too crazy. Happy to test further if we know we'll proceed with this PR. 