### PR TITLE
Wrapped fields in step array to support Multi-Step Form

### DIFF
--- a/src/collections/Forms/index.ts
+++ b/src/collections/Forms/index.ts
@@ -81,34 +81,78 @@ export const generateFormCollection = (formConfig: PluginConfig): CollectionConf
         required: true,
       },
       {
-        name: 'fields',
-        type: 'blocks',
-        blocks: Object.entries(formConfig?.fields || {})
-          .map(([fieldKey, fieldConfig]) => {
-            // let the config enable/disable fields with either boolean values or objects
-            if (fieldConfig !== false) {
-              let block = fields[fieldKey]
+        name: 'step',
+        label: 'Step',
+        interfaceName: 'formStep',
+        type: 'array',
+        maxRows: 3,
+        fields: [
+          {
+            name: 'stepName',
+            type: 'text',
+            admin: {
+              description: 'This would be shown on the step in the UI',
+            },
+          },
+          {
+            name: 'stepHeader',
+            type: 'text',
+            admin: {
+              description: 'This is the header shown while this step is active',
+            },
+          },
+          {
+            name: 'fields',
+            type: 'blocks',
+            blocks: Object.entries(formConfig?.fields || {})
+              .map(([fieldKey, fieldConfig]) => {
+                // let the config enable/disable fields with either boolean values or objects
+                if (fieldConfig !== false) {
+                  let block = fields[fieldKey]
 
-              if (block === undefined && typeof fieldConfig === 'object') {
-                return fieldConfig
-              }
+                  if (block === undefined && typeof fieldConfig === 'object') {
+                    return fieldConfig
+                  }
 
-              if (typeof block === 'object' && typeof fieldConfig === 'object') {
-                return merge<FieldConfig>(block, fieldConfig, {
-                  arrayMerge: (_, sourceArray) => sourceArray,
-                })
-              }
+                  if (typeof block === 'object' && typeof fieldConfig === 'object') {
+                    return merge<FieldConfig>(block, fieldConfig, {
+                      arrayMerge: (_, sourceArray) => sourceArray,
+                    })
+                  }
 
-              if (typeof block === 'function') {
-                return block(fieldConfig)
-              }
+                  if (typeof block === 'function') {
+                    return block(fieldConfig)
+                  }
 
-              return block
-            }
+                  return block
+                }
 
-            return null
-          })
-          .filter(Boolean) as Block[],
+                return null
+              })
+              .filter(Boolean) as Block[],
+          },
+          {
+            name: 'showStepButton',
+            type: 'checkbox',
+          },
+          {
+            name: 'buttonLabel',
+            type: 'text',
+            defaultValue: 'Continue',
+            admin: {
+              condition: (_, { showStepButton }) => Boolean(showStepButton),
+            },
+          },
+          {
+            name: 'previousButtonLabel',
+            type: 'text',
+            defaultValue: 'Previous',
+            admin: {
+              description:
+                'Text for button to go back to previous step.  If button not desired leave blank and no button will render',
+            },
+          },
+        ],
       },
       {
         name: 'submitButtonLabel',


### PR DESCRIPTION
Client needed multi-step forms.  This was my solution, figured others may need it.

Basically, the form fields are wrapped in a 'step' which is numbered and titled.  On the front-end, you can monitor which step an end-user is on and render step controls, etc.

Also, in my case the form is sort of long so this allows the user to fill out the first step and when they click the 'next' button the component submits to the CMS, allowing for a hook to send the data to the marketing system.  This way, even if they only fill out a form partially, they are in a marketing system somewhere for follow up.

Array of steps includes field selection and fields for a 'Continue' button and label as well as a 'previousButtonLabel' to go back a step.

In my case, I maxed the steps to 3 but that could be removed/adjusted.  Figured to leave in for reference.